### PR TITLE
Refactor ViewModel and UI to support loading and error states

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,13 @@ Copy code
 
 This is where the reactive & debounce behavior lives.
 
+## Loading State Enhancement (branch: feature/loading-state)
+
+Adds:
+- `CountryUiState` sealed class (Idle, Loading, Success, Error)
+- ViewModel emits Loading before results
+- Compose UI displays spinner during loading and friendly messages for Idle / No results
+
 ### Key fields:
 ```kotlin
 private val _countries = MutableStateFlow<List<Country>>(emptyList())

--- a/app/src/main/java/com/abhinay/cleancountries/presentation/CountryUiState.kt
+++ b/app/src/main/java/com/abhinay/cleancountries/presentation/CountryUiState.kt
@@ -1,0 +1,13 @@
+package com.abhinay.cleancountries.presentation
+
+import com.abhinay.cleancountries.domain.Country
+
+/**
+ * Created by Abhinay on 02/10/25.
+ */
+sealed class CountryUiState {
+    object Idle: CountryUiState()
+    object Loading: CountryUiState()
+    data class Success(val countries: List<Country>): CountryUiState()
+    data class Error(val message: String): CountryUiState()
+}

--- a/app/src/main/java/com/abhinay/cleancountries/ui/CountriesScreen.kt
+++ b/app/src/main/java/com/abhinay/cleancountries/ui/CountriesScreen.kt
@@ -1,7 +1,7 @@
 package com.abhinay.cleancountries.ui
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -17,65 +18,84 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.abhinay.cleancountries.domain.Country
 import com.abhinay.cleancountries.presentation.CountriesViewModel
+import com.abhinay.cleancountries.presentation.CountryUiState
 
 /**
  * Created by Abhinay on 01/10/25.
  */
 @Composable
 fun CountriesScreen(viewModel: CountriesViewModel) {
-    val countries by viewModel.countries.collectAsState()
+    val query by viewModel.query.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
 
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
     ) {
-        var text by remember { mutableStateOf("") }
+
 
         OutlinedTextField(
-            value = text,
-            onValueChange = {
-                text = it
-                viewModel.onSearchQueryChange(it) // update query; ViewModel debounces + filters
-            },
+            value = query,
+            onValueChange = { viewModel.onSearchQueryChange(it) },
             label = { Text("Search Country") },
             modifier = Modifier.fillMaxWidth()
 
         )
 
         Spacer(modifier = Modifier.height(12.dp))
-        if (countries.isEmpty()) {
-            Text("No results", style = MaterialTheme.typography.bodyLarge)
-        } else {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                items(countries) { country ->
-                    CountryRow(country)
-                    HorizontalDivider(Modifier, DividerDefaults.Thickness, DividerDefaults.color)
 
+        when (uiState) {
+            is CountryUiState.Idle -> {
+                Text("Type something to search…", style = MaterialTheme.typography.bodyLarge)
+            }
+            is CountryUiState.Loading -> {
+                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
                 }
-
+            }
+            is CountryUiState.Success -> {
+                val countries = (uiState as CountryUiState.Success).countries
+                if (countries.isEmpty()) {
+                    Text("No results found", style = MaterialTheme.typography.bodyLarge)
+                } else {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(countries) { country ->
+                            CountryRow(countryName = country.name, countryDetails = "${country.code} • ${country.phoneCode}")
+                            HorizontalDivider(
+                                Modifier,
+                                DividerDefaults.Thickness,
+                                DividerDefaults.color
+                            )
+                        }
+                    }
+                }
+            }
+            is CountryUiState.Error -> {
+                val message = (uiState as CountryUiState.Error).message
+                Text(
+                    text = message,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.fillMaxWidth(),
+                    style = MaterialTheme.typography.bodyLarge
+                )
             }
         }
-
     }
-
 }
 
 @Composable
-private fun CountryRow(country: Country) {
+private fun CountryRow(countryName: String, countryDetails: String) {
     Column(modifier = Modifier
         .fillMaxWidth()
         .padding(vertical = 12.dp)) {
-        Text(text = country.name, style = MaterialTheme.typography.titleMedium)
+        Text(text = countryName, style = MaterialTheme.typography.titleMedium)
         Spacer(modifier = Modifier.height(4.dp))
-        Text(text = "${country.code} • ${country.phoneCode}", style = MaterialTheme.typography.bodySmall)
+        Text(text = countryDetails, style = MaterialTheme.typography.bodySmall)
     }
 }
 


### PR DESCRIPTION
This commit introduces a more robust UI experience by handling loading and error states when fetching and displaying country data.

Key changes:

- **`CountryUiState.kt`:** Added a new sealed class `CountryUiState` to represent the different states of the UI: `Idle`, `Loading`, `Success(List<Country>)`, and `Error(String)`.
- **`CountriesViewModel.kt`:**
    - Modified to emit `CountryUiState` instead of just a list of countries.
    - The `searchQuery` flow now maps the results from the `GetCountriesUseCase` to the appropriate `CountryUiState` (e.g., `Loading` before the search, `Success` with data, or `Error` if an exception occurs).
    - The initial loading of all countries has been removed, and the behavior for a blank query now also flows through the `CountryUiState` emission.
    - `_countries` StateFlow renamed to `_uiState` to reflect the new state management.
    - `countries` StateFlow renamed to `uiState`.
- **`CountriesScreen.kt`:**
    - Updated to observe the `uiState` from the `CountriesViewModel`.
    - Implemented a `when` expression to render different UI components based on the current `CountryUiState`:
        - `Idle`: Displays a "Type something to search…" message.
        - `Loading`: Shows a `CircularProgressIndicator`. - `Success`: Displays the list of countries or a "No results found" message if the list is empty. - `Error`: Shows the error message.
    - The `CountryRow` composable now accepts `countryName` and `countryDetails` as separate string parameters.
- **`Readme.md`:**
    - Added a new section "Loading State Enhancement" detailing these changes.